### PR TITLE
Add DT_ALWAYS_SERIALIZE option

### DIFF
--- a/example/albums/serializers.py
+++ b/example/albums/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from .models import Album
+from .models import Album, Artist
 
 
 class AlbumSerializer(serializers.ModelSerializer):
@@ -27,4 +27,18 @@ class AlbumSerializer(serializers.ModelSerializer):
         fields = (
             'DT_RowId', 'DT_RowAttr', 'rank', 'name',
             'year', 'artist_name', 'genres',
+        )
+
+
+class ArtistSerializer(serializers.ModelSerializer):
+    id = serializers.IntegerField(read_only=True)
+
+    # Specifying fields in DT_ALWAYS_SERIALIZE will also
+    # force them to always be serialized.
+    DT_ALWAYS_SERIALIZE = ('id',)
+
+    class Meta:
+        model = Artist
+        fields = (
+            'id', 'name',
         )

--- a/example/albums/serializers.py
+++ b/example/albums/serializers.py
@@ -33,12 +33,11 @@ class AlbumSerializer(serializers.ModelSerializer):
 class ArtistSerializer(serializers.ModelSerializer):
     id = serializers.IntegerField(read_only=True)
 
-    # Specifying fields in DT_ALWAYS_SERIALIZE will also
-    # force them to always be serialized.
-    DT_ALWAYS_SERIALIZE = ('id',)
-
     class Meta:
         model = Artist
         fields = (
             'id', 'name',
         )
+        # Specifying fields in datatables_always_serialize
+        # will also force them to always be serialized.
+        datatables_always_serialize = ('id',)

--- a/example/albums/views.py
+++ b/example/albums/views.py
@@ -1,9 +1,10 @@
 from django.shortcuts import render
 
 from rest_framework import viewsets
+from rest_framework.response import Response
 
-from .models import Album
-from .serializers import AlbumSerializer
+from .models import Album, Artist
+from .serializers import AlbumSerializer, ArtistSerializer
 
 
 def index(request):
@@ -13,3 +14,12 @@ def index(request):
 class AlbumViewSet(viewsets.ModelViewSet):
     queryset = Album.objects.all().order_by('rank')
     serializer_class = AlbumSerializer
+
+
+class ArtistViewSet(viewsets.ViewSet):
+    queryset = Artist.objects.all().order_by('name')
+    serializer_class = ArtistSerializer
+
+    def list(self, request):
+        serializer = self.serializer_class(self.queryset, many=True)
+        return Response(serializer.data)

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -8,6 +8,7 @@ from albums import views
 
 router = routers.DefaultRouter()
 router.register(r'albums', views.AlbumViewSet)
+router.register(r'artists', views.ArtistViewSet)
 
 
 urlpatterns = [

--- a/rest_framework_datatables/renderers.py
+++ b/rest_framework_datatables/renderers.py
@@ -39,13 +39,15 @@ class DatatablesRenderer(JSONRenderer):
         # add datatables "draw" parameter
         new_data['draw'] = int(request.query_params.get('draw', '1'))
 
+        serializer_class = None
         if hasattr(view, 'get_serializer_class'):
-            force_serialize = getattr(
-                view.get_serializer_class(), 'DT_ALWAYS_SERIALIZE', ()
-            )
+            serializer_class = view.get_serializer_class()
         elif hasattr(view, 'serializer_class'):
+            serializer_class = view.serializer_class
+
+        if serializer_class is not None and hasattr(serializer_class, 'Meta'):
             force_serialize = getattr(
-                view.serializer_class, 'DT_ALWAYS_SERIALIZE', ()
+                serializer_class, 'datatables_always_serialize', ()
             )
         else:
             force_serialize = ()

--- a/rest_framework_datatables/renderers.py
+++ b/rest_framework_datatables/renderers.py
@@ -47,7 +47,7 @@ class DatatablesRenderer(JSONRenderer):
 
         if serializer_class is not None and hasattr(serializer_class, 'Meta'):
             force_serialize = getattr(
-                serializer_class, 'datatables_always_serialize', ()
+                serializer_class.Meta, 'datatables_always_serialize', ()
             )
         else:
             force_serialize = ()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -77,6 +77,31 @@ class TestApiTestCase(TestCase):
         self.assertTrue('DT_RowId' in result['data'][0])
         self.assertTrue('DT_RowAttr' in result['data'][0])
 
+    def test_dt_force_serialize(self):
+        AlbumSerializer.DT_ALWAYS_SERIALIZE = ('year',)
+        response = self.client.get('/api/albums/?format=datatables&length=10&start=0&columns[0][data]=&columns[1][data]=name')
+        result = response.json()
+        self.assertTrue('year' in result['data'][0])
+
+        delattr(AlbumSerializer, 'DT_ALWAYS_SERIALIZE')
+
+    def test_dt_force_serialize_class(self):
+        AlbumSerializer.DT_ALWAYS_SERIALIZE = ('year',)
+
+        def get_serializer_class(self):
+            return AlbumSerializer
+
+        delattr(AlbumViewSet, 'serializer_class')
+        AlbumViewSet.get_serializer_class = get_serializer_class
+
+        response = self.client.get('/api/albums/?format=datatables&length=10&start=0&columns[0][data]=&columns[1][data]=name')
+        result = response.json()
+        self.assertTrue('year' in result['data'][0])
+
+        delattr(AlbumSerializer, 'DT_ALWAYS_SERIALIZE')
+        delattr(AlbumViewSet, 'get_serializer_class')
+        AlbumViewSet.serializer_class = AlbumSerializer
+
     def test_filtering_simple(self):
         response = self.client.get('/api/albums/?format=datatables&columns[0][data]=name&columns[0][searchable]=true&search[value]=are+you+exp')
         expected = (1, 15, 'Are You Experienced')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -78,7 +78,7 @@ class TestApiTestCase(TestCase):
         self.assertTrue('DT_RowAttr' in result['data'][0])
 
     def test_dt_force_serialize_class(self):
-        AlbumSerializer.DT_ALWAYS_SERIALIZE = ('year',)
+        AlbumSerializer.Meta.datatables_always_serialize = ('year',)
         response = self.client.get('/api/albums/?format=datatables&length=10&start=0&columns[0][data]=&columns[1][data]=name')
         result = response.json()
         self.assertTrue('year' in result['data'][0])

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -83,7 +83,7 @@ class TestApiTestCase(TestCase):
         result = response.json()
         self.assertTrue('year' in result['data'][0])
 
-        delattr(AlbumSerializer, 'DT_ALWAYS_SERIALIZE')
+        delattr(AlbumSerializer.Meta, 'datatables_always_serialize')
 
     def test_dt_force_serialize_generic(self):
         response = self.client.get('/api/artists/?format=datatables&length=10&start=0&columns[0][data]=&columns[1][data]=name')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -77,30 +77,18 @@ class TestApiTestCase(TestCase):
         self.assertTrue('DT_RowId' in result['data'][0])
         self.assertTrue('DT_RowAttr' in result['data'][0])
 
-    def test_dt_force_serialize(self):
-        AlbumSerializer.DT_ALWAYS_SERIALIZE = ('year',)
-        response = self.client.get('/api/albums/?format=datatables&length=10&start=0&columns[0][data]=&columns[1][data]=name')
-        result = response.json()
-        self.assertTrue('year' in result['data'][0])
-
-        delattr(AlbumSerializer, 'DT_ALWAYS_SERIALIZE')
-
     def test_dt_force_serialize_class(self):
         AlbumSerializer.DT_ALWAYS_SERIALIZE = ('year',)
-
-        def get_serializer_class(self):
-            return AlbumSerializer
-
-        delattr(AlbumViewSet, 'serializer_class')
-        AlbumViewSet.get_serializer_class = get_serializer_class
-
         response = self.client.get('/api/albums/?format=datatables&length=10&start=0&columns[0][data]=&columns[1][data]=name')
         result = response.json()
         self.assertTrue('year' in result['data'][0])
 
         delattr(AlbumSerializer, 'DT_ALWAYS_SERIALIZE')
-        delattr(AlbumViewSet, 'get_serializer_class')
-        AlbumViewSet.serializer_class = AlbumSerializer
+
+    def test_dt_force_serialize_generic(self):
+        response = self.client.get('/api/artists/?format=datatables&length=10&start=0&columns[0][data]=&columns[1][data]=name')
+        result = response.json()
+        self.assertTrue('id' in result['data'][0])
 
     def test_filtering_simple(self):
         response = self.client.get('/api/albums/?format=datatables&columns[0][data]=name&columns[0][searchable]=true&search[value]=are+you+exp')


### PR DESCRIPTION
I wanted a way to always serialize fields while keeping my API as clean as possible (avoiding use of DT_Row).

I've added a check in the renderer that looks for a `DT_ALWAYS_SERIALIZE` tuple on the `serializer_class`, and prevents the specified fields from being filtered out.

I also removed the `return` from `_filter_unused_fields`, as the result dict is passed by reference.

Example usage:
```
class AlbumSerializer(serializers.ModelSerializer):
    id = serializers.IntegerField(read_only=True)

    DT_ALWAYS_SERIALIZE = ('id', 'rank',)

    class Meta:
        model = Album
        fields = (
            'id', 'rank', 'name', 'year',
        )
```
The `id` and `rank` fields will now always be available, regardless of what columns are used in the table.
