### PR TITLE
Nested Serializers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist/
 *.egg-info/
 MANIFEST
 docs/_build
+/.idea

--- a/example/albums/serializers.py
+++ b/example/albums/serializers.py
@@ -3,8 +3,23 @@ from rest_framework import serializers
 from .models import Album, Artist
 
 
+class ArtistSerializer(serializers.ModelSerializer):
+    id = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = Artist
+        fields = (
+            'id', 'name',
+        )
+        # Specifying fields in datatables_always_serialize
+        # will also force them to always be serialized.
+        datatables_always_serialize = ('id',)
+
+
 class AlbumSerializer(serializers.ModelSerializer):
     artist_name = serializers.ReadOnlyField(source='artist.name')
+    # DRF-Datatables can deal with nested serializers as well.
+    artist = ArtistSerializer()
     genres = serializers.SerializerMethodField()
 
     def get_genres(self, album):
@@ -26,18 +41,7 @@ class AlbumSerializer(serializers.ModelSerializer):
         model = Album
         fields = (
             'DT_RowId', 'DT_RowAttr', 'rank', 'name',
-            'year', 'artist_name', 'genres',
+            'year', 'artist_name', 'genres', 'artist',
         )
 
 
-class ArtistSerializer(serializers.ModelSerializer):
-    id = serializers.IntegerField(read_only=True)
-
-    class Meta:
-        model = Artist
-        fields = (
-            'id', 'name',
-        )
-        # Specifying fields in datatables_always_serialize
-        # will also force them to always be serialized.
-        datatables_always_serialize = ('id',)

--- a/example/albums/templates/albums/albums.html
+++ b/example/albums/templates/albums/albums.html
@@ -41,6 +41,7 @@
             <thead>
                 <tr>
                     <th data-data="rank">Rank</th>
+                    <th data-data="artist_name" data-name="artist.name">Artist</th>
                     <th data-data="name">Album name</th>
                 </tr>
             </thead>
@@ -64,7 +65,9 @@ $(document).ready(function() {
         "ajax": "/api/albums/?format=datatables",
         "columns": [
             {"data": "rank", "searchable": false},
-            {"data": "artist_name", "name": "artist.name"},
+            // Use dot notation to reference nested serializers.
+            // This data: could alternatively be displayed with the serializer's ReadOnlyField as well, as seen in the minimal example.
+            {"data": "artist.name", "name": "artist.name"},
             {"data": "name"},
             {"data": "year"},
             {"data": "genres", "name": "genres.name", "sortable": false},

--- a/rest_framework_datatables/renderers.py
+++ b/rest_framework_datatables/renderers.py
@@ -65,7 +65,7 @@ class DatatablesRenderer(JSONRenderer):
             col = request.query_params.get('columns[%d][data]' % i)
             if col is None:
                 break
-            cols.append(col)
+            cols.append(col.split('.').pop(0))
             i += 1
         if len(cols):
             data = result['data']

--- a/rest_framework_datatables/renderers.py
+++ b/rest_framework_datatables/renderers.py
@@ -78,4 +78,4 @@ class DatatablesRenderer(JSONRenderer):
                     if (k not in cols
                             and not k.startswith('DT_Row')
                             and k not in force_serialize):
-                        result['data'][i].pop(k)
+                            result['data'][i].pop(k)


### PR DESCRIPTION
Hey there,

Here's the work I've done on nested serializers, including tests and documentation. So far I have made it so the top level fields aren't filtered out (i.e. the fields that reference the nested serializers). In addition, I made it so that way the `name` field can be used to filter on multiple fields using comma-separated values.

I changed a lot of the documentation to use dot notation instead of double-underscore notation to avoid confusion, though I left a reference in regarding double-underscore notation since it can be used in `name` fields (though not `data` fields, since Datatables doesn't know how to deal with it).

Hopefully all of this fits in with what you want to do with the project.

In addition, I have also done some work on adding an additional param `?keep=` that does the same thing as `datatables_always_serialize`, but does so at runtime instead of having to be hardcoded into the api. If you want, I can do another PR with that bit too.

Regards,
Dustin