### PR TITLE
Added keep= param

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -201,6 +201,15 @@ What we just did:
 
     In the above example, the fields 'id' and 'rank' will always be serialized in the response regardless of fields requested in the Datatables request.
 
+.. hint::
+
+    Alternatively, if you wish to choose which fields to preserve at runtime rather than hardcoding them into your serializer models, use the ``?keep=`` param along with the fields you wish to maintain (comma separated). For example, if you wished to preserve ``id`` and ``rank`` as before, you would simply use the following API call:
+
+
+.. code:: html
+
+    data-ajax="/api/albums/?format=datatables&keep=id,rank"
+
 .. important::
 
     To sum up, **the most important things** to remember here are:

--- a/rest_framework_datatables/renderers.py
+++ b/rest_framework_datatables/renderers.py
@@ -59,6 +59,10 @@ class DatatablesRenderer(JSONRenderer):
         )
 
     def _filter_unused_fields(self, request, result, force_serialize):
+        # list of params to keep, triggered by ?keep= and can be comma separated.
+        keep = request.query_params.get('keep')
+        if keep is None:
+            keep = []
         cols = []
         i = 0
         while True:
@@ -77,5 +81,7 @@ class DatatablesRenderer(JSONRenderer):
                 for k in keys:
                     if (k not in cols
                             and not k.startswith('DT_Row')
-                            and k not in force_serialize):
+                            and k not in force_serialize
+                            and not k.startswith('id')
+                            and k not in keep):
                             result['data'][i].pop(k)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -85,6 +85,19 @@ class TestApiTestCase(TestCase):
 
         delattr(AlbumSerializer.Meta, 'datatables_always_serialize')
 
+    def test_param_keep_field(self):
+        response = self.client.get(
+            '/api/albums/?format=datatables&length=10&columns[0][data]=artist.name&columns[0][name]=artist.name&keep=year')
+        expected = (15, 15, 1967)
+        result = response.json()
+        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['year']), expected)
+
+    def test_param_keep_field_search(self):
+        response = self.client.get('/api/albums/?format=datatables&length=10&columns[0][data]=artist.name&columns[0][name]=artist.name,year&columns[0][searchable]=true&keep=year&search[value]=1968')
+        expected = (1, 15, 'The Beatles', 1968)
+        result = response.json()
+        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist']['name'], result['data'][0]['year']), expected)
+
     def test_dt_force_serialize_generic(self):
         response = self.client.get('/api/artists/?format=datatables&length=10&start=0&columns[0][data]=&columns[1][data]=name')
         result = response.json()


### PR DESCRIPTION
> Added ?keep= param to enable dynamic preservation of fields during runtime as an alternative to using the datatables_always_serialize option in a serializer.

Hey,

I wrote some code to dynamically preserve fields using query params instead of hardcoding them into the serializers using `datatables_always_serialize`. This code still preserves both options, but provides the opportunity for users to maintain their existing serializers without having to make any further changes. All they need to do is use the `?keep=` param to preserve fields.

I also added `id` as an always preserved field, but this was more for my own personal needs than the project as a whole.

Please check out my code and let me know what you think.