### PR TITLE
typo in method name

### DIFF
--- a/rest_framework_datatables/pagination.py
+++ b/rest_framework_datatables/pagination.py
@@ -26,7 +26,7 @@ class DatatablesMixin(object):
             count = view._datatables_filtered_count
             del view._datatables_filtered_count
         else:  # pragma: no cover
-            count = queryset.Count()
+            count = queryset.count()
         if hasattr(view, '_datatables_total_count'):
             total_count = view._datatables_total_count
             del view._datatables_total_count


### PR DESCRIPTION
I use to have ```AttributeError: 'QuerySet' object has no attribute 'Count'``` until I applied this patch