### PR TITLE
Meta option 'datatables_extra_json' on view for adding key/value pairs to rendered JSON

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -207,6 +207,25 @@ In the above example, the fields 'id' and 'rank' will always be serialized in th
 
         data-ajax="/api/albums/?format=datatables&keep=id,rank"
 
+In order to provide additional context of the data from the view, you can use the ``datatables_extra_json`` Meta option.
+
+.. code:: python
+
+    class AlbumViewSet(viewsets.ModelViewSet):
+        queryset = Album.objects.all().order_by('rank')
+        serializer_class = AlbumSerializer
+
+        def get_options(self):
+            return "options", {
+                "artist": [{'label': obj.name, 'value': obj.pk} for obj in Artist.objects.all()],
+                "genre": [{'label': obj.name, 'value': obj.pk} for obj in Genre.objects.all()]
+            }
+
+        class Meta:
+            datatables_extra_json = ('get_options', )
+
+In the above example, the 'get_options' method will be called to populate the rendered JSON with the key and value from the method's return tuple.
+
 .. important::
 
     To sum up, **the most important things** to remember here are:

--- a/example/albums/views.py
+++ b/example/albums/views.py
@@ -3,7 +3,7 @@ from django.shortcuts import render
 from rest_framework import viewsets
 from rest_framework.response import Response
 
-from .models import Album, Artist
+from .models import Album, Artist, Genre
 from .serializers import AlbumSerializer, ArtistSerializer
 
 
@@ -11,9 +11,22 @@ def index(request):
     return render(request, 'albums/albums.html')
 
 
+def get_album_options():
+    return "options", {
+        "artist": [{'label': obj.name, 'value': obj.pk} for obj in Artist.objects.all()],
+        "genre": [{'label': obj.name, 'value': obj.pk} for obj in Genre.objects.all()]
+    }
+
+
 class AlbumViewSet(viewsets.ModelViewSet):
     queryset = Album.objects.all().order_by('rank')
     serializer_class = AlbumSerializer
+
+    def get_options(self):
+        return get_album_options()
+
+    class Meta:
+        datatables_extra_json = ('get_options', )
 
 
 class ArtistViewSet(viewsets.ViewSet):
@@ -23,3 +36,9 @@ class ArtistViewSet(viewsets.ViewSet):
     def list(self, request):
         serializer = self.serializer_class(self.queryset, many=True)
         return Response(serializer.data)
+
+    def get_options(self):
+        return get_album_options()
+
+    class Meta:
+        datatables_extra_json = ('get_options', )

--- a/rest_framework_datatables/renderers.py
+++ b/rest_framework_datatables/renderers.py
@@ -102,7 +102,7 @@ class DatatablesRenderer(JSONRenderer):
                 raise TypeError("extra_json_funcs entry {0} is not a view method.".format(func))
             method = getattr(view, func)
             if not callable(method):
-                raise TypeError("extra_json_funcs entry {0} is not callable.")
+                raise TypeError("extra_json_funcs entry {0} is not callable.".format(func))
             key, val = method()
             if key in read_only_keys:
                 raise ValueError("Duplicate key found: {key}".format(key=key))

--- a/rest_framework_datatables/renderers.py
+++ b/rest_framework_datatables/renderers.py
@@ -105,7 +105,7 @@ class DatatablesRenderer(JSONRenderer):
             method = getattr(view, func)
             if not callable(method):
                 raise TypeError(
-                    "extra_json_funcs: {0}  not callable.".format(func)
+                    "extra_json_funcs: {0} not callable.".format(func)
                 )
             key, val = method()
             if key in read_only_keys:

--- a/rest_framework_datatables/renderers.py
+++ b/rest_framework_datatables/renderers.py
@@ -88,21 +88,25 @@ class DatatablesRenderer(JSONRenderer):
                     continue
                 for k in keys:
                     if (
-                        k not in cols
-                        and not k.startswith('DT_Row')
-                        and k not in force_serialize
-                        and k not in keep
+                            k not in cols
+                            and not k.startswith('DT_Row')
+                            and k not in force_serialize
+                            and k not in keep
                     ):
                         result['data'][i].pop(k)
 
     def _filter_extra_json(self, view, result, extra_json_funcs):
-        read_only_keys = result.keys()  # everything that's present should remain unaltered
+        read_only_keys = result.keys()  # don't alter anything
         for func in extra_json_funcs:
             if not hasattr(view, func):
-                raise TypeError("extra_json_funcs entry {0} is not a view method.".format(func))
+                raise TypeError(
+                    "extra_json_funcs: {0} not a view method.".format(func)
+                )
             method = getattr(view, func)
             if not callable(method):
-                raise TypeError("extra_json_funcs entry {0} is not callable.".format(func))
+                raise TypeError(
+                    "extra_json_funcs: {0}  not callable.".format(func)
+                )
             key, val = method()
             if key in read_only_keys:
                 raise ValueError("Duplicate key found: {key}".format(key=key))

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -137,7 +137,7 @@ class DatatablesRendererTestCase(TestCase):
             renderer.render(obj, 'application/json', {'request': request, 'view': view})
             self.assertEqual(True, False, "TypeError expected; did not occur.")
         except TypeError as e:
-            self.assertEqual(e.__str__(), "extra_json_funcs entry test_callback is not a view method.")
+            self.assertEqual(e.__str__(), "extra_json_funcs: test_callback not a view method.")
 
     def test_render_extra_json_attr_not_callable(self):
         class TestAPIView(APIView):
@@ -155,7 +155,7 @@ class DatatablesRendererTestCase(TestCase):
             renderer.render(obj, 'application/json', {'request': request, 'view': view})
             self.assertEqual(True, False, "TypeError expected; did not occur.")
         except TypeError as e:
-            self.assertEqual(e.__str__(), "extra_json_funcs entry test_callback is not callable.")
+            self.assertEqual(e.__str__(), "extra_json_funcs: test_callback not callable.")
 
     def test_render_extra_json_clashes(self):
         class TestAPIView(APIView):


### PR DESCRIPTION
I have been using DataTables for a while and recently began overhauling my UI. This project caught my attention, and quickly swapped out a lot of boilerplate I'd previously been using (thanks!). I then moved on to the Editor plugin. Editor's implementation of multiple/join tables can make use of an additional 'options' key in the JSON (for pk/name pairs in form controls). As such, I've added a Metaclass option 'datatables_extra_json' to the view. It defines a set of callables (on the view) that will each return a key/value pair (tuple) to be added to the rendered JSON. This runs at the end of rendering, and won't change any JSON key that was already there.