### PR TITLE
Add optional column sorting to handle ties

### DIFF
--- a/rest_framework_datatables/filters.py
+++ b/rest_framework_datatables/filters.py
@@ -74,6 +74,15 @@ class DatatablesFilterBackend(BaseFilterBackend):
 
         # order queryset
         if len(ordering):
+            if hasattr(view, '_datatables_additional_order_by'):
+                additional = view._datatables_additional_order_by
+                # Django will actually only take the first occurrence if the
+                # same column is added multiple times in an order_by, but it
+                # feels cleaner to double check for duplicate anyway.
+                if not any((o[1:] if o[0] == '-' else o) == additional
+                           for o in ordering):
+                    ordering.append(additional)
+
             queryset = queryset.order_by(*ordering)
         return queryset
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,0 +1,41 @@
+from albums.models import Album
+from albums.serializers import AlbumSerializer
+
+from django.conf.urls import url
+from django.test.utils import override_settings
+from django.test import TestCase
+
+from rest_framework.generics import ListAPIView
+from rest_framework.test import (
+    APIClient,
+)
+from rest_framework_datatables.pagination import (
+    DatatablesLimitOffsetPagination,
+)
+
+class TestFilterTestCase(TestCase):
+    class TestAPIView(ListAPIView):
+        serializer_class = AlbumSerializer
+        pagination_class = DatatablesLimitOffsetPagination
+        _datatables_additional_order_by = 'year'
+
+        def get_queryset(self):
+            return Album.objects.all()
+
+    fixtures = ['test_data']
+
+    def setUp(self):
+        self.client = APIClient()
+
+    @override_settings(ROOT_URLCONF=__name__)
+    def test_additional_order_by(self):
+        response = self.client.get('/api/additionalorderby/?format=datatables&draw=1&columns[0][data]=rank&columns[0][name]=&columns[0][searchable]=true&columns[0][orderable]=true&columns[0][search][value]=&columns[0][search][regex]=false&columns[1][data]=artist_name&columns[1][name]=artist.name&columns[1][searchable]=true&columns[1][orderable]=true&columns[1][search][value]=&columns[1][search][regex]=false&columns[2][data]=name&columns[2][name]=&columns[2][searchable]=true&columns[2][orderable]=true&columns[2][search][value]=&columns[2][search][regex]=false&order[0][column]=1&order[0][dir]=desc&start=4&length=1&search[value]=&search[regex]=false')
+        # Would be "Sgt. Pepper's Lonely Hearts Club Band" without the additional order by
+        expected = (15, 15, 'Rubber Soul')
+        result = response.json()
+        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['name']), expected)
+
+
+urlpatterns = [
+    url('^api/additionalorderby', TestFilterTestCase.TestAPIView.as_view()),
+]


### PR DESCRIPTION
If sorting is done on a single column with more duplicates
than the page size it's possible than some rows are never
retrieved as we traverse through our datatable. This is because
of how order by together with limit and offset works in the database.

As a workaround for this problem we add a second column to sort by
in the case of ties.