### PR TITLE
Add support for disabling pagination (aka show all)

### DIFF
--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -138,5 +138,5 @@ REST_FRAMEWORK = {
         'rest_framework_datatables.filters.DatatablesFilterBackend',
     ),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework_datatables.pagination.DatatablesPageNumberPagination',
-    'PAGE_SIZE': 50,
+    'PAGE_SIZE': 10,
 }

--- a/rest_framework_datatables/pagination.py
+++ b/rest_framework_datatables/pagination.py
@@ -42,7 +42,10 @@ class DatatablesPageNumberPagination(DatatablesMixin, PageNumberPagination):
             return super(
                 DatatablesPageNumberPagination, self
             ).paginate_queryset(queryset, request, view)
-        if request.query_params.get('length') is None:
+
+        length = request.query_params.get('length')
+
+        if length is None or length == '-1':
             return None
         self.count, self.total_count = self.get_count_and_total_count(
             queryset, view

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -41,9 +41,15 @@ class TestApiTestCase(TestCase):
 
     def test_pagenumber_pagination(self):
         response = self.client.get('/api/albums/?format=datatables&length=10&start=10&columns[0][data]=name&columns[1][data]=artist_name&draw=1')
-        expected = (15, 15, 'Elvis Presley')
+        expected = (15, 15, 5, 'Elvis Presley')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
+        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], len(result['data']), result['data'][0]['artist_name']), expected)
+
+    def test_pagenumber_pagination_show_all(self):
+        response = self.client.get('/api/albums/?format=datatables&length=-1&columns[0][data]=name&columns[1][data]=artist_name&draw=1')
+        expected = (15, 15, 15, 'The Beatles')
+        result = response.json()
+        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], len(result['data']), result['data'][0]['artist_name']), expected)
 
     def test_pagenumber_pagination_invalid_page(self):
         response = self.client.get('/api/albums/?format=datatables&length=10&start=20&columns[0][data]=name&columns[1][data]=artist_name&draw=1')


### PR DESCRIPTION
Disable pagination when the client requests show all by using flag value `length == -1`.

This gets drft in sync with datatables' [documentation example](https://datatables.net/reference/option/lengthMenu).