### PR TITLE
Don't assume a column with no 'data' attribute indicates the end of t…

### DIFF
--- a/rest_framework_datatables/filters.py
+++ b/rest_framework_datatables/filters.py
@@ -90,10 +90,13 @@ class DatatablesFilterBackend(BaseFilterBackend):
         fields = []
         i = 0
         while True:
+            if not getter('columns[%d]' % i):
+                break
             col = 'columns[%d][%s]'
             data = getter(col % (i, 'data'))
             if data is None or not data:
-                break
+                i += 1 
+                continue
             name = getter(col % (i, 'name'))
             if not name:
                 name = data


### PR DESCRIPTION
…he row

Rather than assume that a column without a `data` attribute indicates the row is complete, check the column index, then if it's there, proceed as before. If there is no column at the index, assume that's the end and break like before.

This corrects the issue described in #64 