### PR TITLE
Remove alert on missing values

### DIFF
--- a/example/albums/templates/albums/albums.html
+++ b/example/albums/templates/albums/albums.html
@@ -67,7 +67,7 @@ $(document).ready(function() {
             {"data": "rank", "searchable": false},
             // Use dot notation to reference nested serializers.
             // This data: could alternatively be displayed with the serializer's ReadOnlyField as well, as seen in the minimal example.
-            {"data": "artist.name", "name": "artist.name"},
+            {"data": "artist.name", "name": "artist.name", defaultContent: "-"},
             {"data": "name"},
             {"data": "year"},
             {"data": "genres", "name": "genres.name", "sortable": false},


### PR DESCRIPTION
If the api omits a value, Datatables complains. If you specify a default value for missing values Datatables will use that and not show an alert.