### PR TITLE
Update limit offset pagination for POST support, update example project

### DIFF
--- a/example/albums/templates/albums/albums.html
+++ b/example/albums/templates/albums/albums.html
@@ -48,6 +48,24 @@
         </table>
     </div>
 </div>
+<div class="row">
+    <div class="col-sm-12 text-center">
+        <h4 class="bg-primary text-white p-2" style="margin: 15px;">Example Using POST</h4>
+    </div>
+</div>
+<div class="row">
+    <div class="col-sm-12">
+        <table id="albums_post" class="table table-striped table-bordered" style="width:100%">
+            <thead>
+                <tr>
+                    <th>Rank</th>
+                    <th>Artist</th>
+                    <th>Album Name</th>
+                </tr>
+            </thead>
+        </table>
+    </div>
+</div>
 <footer class="footer" style="margin-top: 25px;">
     <div class="container">
         <p class="text-muted text-center">
@@ -85,6 +103,21 @@ $(document).ready(function() {
     $('#albums_minimal').DataTable({
         "search": {"regex": true},
         "language": {"searchPlaceholder": "regular expression"}
+    });
+    $('#albums_post').DataTable({
+        "serverSide": true,
+        "ajax": {
+            "url": "api/post-list/albums/?format=datatables",
+            "type": "POST",
+            "beforeSend": function(xhr) {
+                xhr.setRequestHeader("X-CSRFToken", "{{ csrf_token|escapejs }}");
+            }
+        },
+        "columns": [
+            {"data": "rank", "searchable": false},
+            {"data": "artist.name", "name": "artist.name"},
+            {"data": "name"},
+        ]
     });
 });
 </script>

--- a/example/albums/views.py
+++ b/example/albums/views.py
@@ -1,7 +1,9 @@
 from django.shortcuts import render
 
 from rest_framework import viewsets
+from rest_framework import generics
 from rest_framework.response import Response
+from rest_framework_datatables import pagination as dt_pagination
 
 from .models import Album, Artist, Genre
 from .serializers import AlbumSerializer, ArtistSerializer
@@ -42,3 +44,12 @@ class ArtistViewSet(viewsets.ViewSet):
 
     class Meta:
         datatables_extra_json = ('get_options', )
+
+
+class AlbumPostListView(generics.ListAPIView):
+    queryset = Album.objects.all().order_by('rank')
+    serializer_class = AlbumSerializer
+    pagination_class = dt_pagination.DatatablesLimitOffsetPagination
+
+    def post(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -14,5 +14,6 @@ router.register(r'artists', views.ArtistViewSet)
 urlpatterns = [
     url('^admin/', admin.site.urls),
     url('^api/', include(router.urls)),
+    url('^api/post-list/albums', views.AlbumPostListView.as_view(), name='albums_post_list'),
     url('', views.index, name='albums')
 ]

--- a/rest_framework_datatables/pagination.py
+++ b/rest_framework_datatables/pagination.py
@@ -88,6 +88,28 @@ class DatatablesPageNumberPagination(DatatablesMixin, PageNumberPagination):
 
 
 class DatatablesLimitOffsetPagination(DatatablesMixin, LimitOffsetPagination):
+    def get_limit(self, request):
+        try:
+            limit_value = int(get_param(request, self.limit_query_param))
+            if limit_value <= 0:
+                raise ValueError
+
+            if self.max_limit is not None:
+                return min(limit_value, self.max_limit)
+            return limit_value
+        except ValueError:
+            return self.default_limit
+
+    def get_offset(self, request):
+        try:
+            offset_value = int(get_param(request, self.offset_query_param))
+            if offset_value < 0:
+                raise ValueError
+
+            return offset_value
+        except ValueError:
+            return 0
+
     def paginate_queryset(self, queryset, request, view=None):
         if request.accepted_renderer.format == 'datatables':
             self.is_datatable_request = True


### PR DESCRIPTION
The `DataTablesLimitOffsetPagination` class doesn't seem to work as expected when using POST requests to retrieve datatables format data. This pull request adds implementations of `get_limit` and `get_offset` to this class to make the behavior more inline with expected behavior. In addition, this pull request adds an example `DataTable` which uses POST requests.

Fixes #80 