### PR TITLE
added global search support to 'YADCFModelMultipleChoiceFilter'

### DIFF
--- a/example/albums/templates/albums/albums.html
+++ b/example/albums/templates/albums/albums.html
@@ -151,7 +151,7 @@ $(document).ready(function() {
         "columns": [
             {"data": "rank", "searchable": false},
             {"data": "artist_name", "name": "artist_name"},
-            {"data": "name", "searchable": false},
+            {"data": "name"},
         ]
     });
     yadcf.init(albumFilterTable, [

--- a/example/albums/templates/albums/albums.html
+++ b/example/albums/templates/albums/albums.html
@@ -150,8 +150,8 @@ $(document).ready(function() {
         },
         "columns": [
             {"data": "rank", "searchable": false},
-            {"data": "artist_name", "name": "artist_name",},
-            {"data": "name"},
+            {"data": "artist_name", "name": "artist_name"},
+            {"data": "name", "searchable": false},
         ]
     });
     yadcf.init(albumFilterTable, [

--- a/rest_framework_datatables/django_filters/filters.py
+++ b/rest_framework_datatables/django_filters/filters.py
@@ -52,7 +52,7 @@ class GlobalFilter(SwitchRegexFilter):
     global filtering without using django-filter.
 
     *Must* be used with DjangoFilterBackend which combines the global
-    and colum searches in the correct way and with
+    and column searches in the correct way and with
     DatatablesFilterSet, which ensures that the correct attributes are
     set to make this work.
 
@@ -81,7 +81,7 @@ class GlobalFilter(SwitchRegexFilter):
     """
 
     def global_q(self):
-        """Return a Q-Object for the local search for this column"""
+        """Return a Q-Object for the global search for this column"""
         ret = Q()
         if self.global_search_value:
             ret = Q(**{self.global_lookup: self.global_search_value})


### PR DESCRIPTION
This is an update to the example application.

This adds a `global_q()` method to `YADCFModelMultipleChoiceFilter` so that the global search works correctly.

There are a couple of typo fixes as well.
