### PR TITLE
Fixed crash on missing data key in field

### DIFF
--- a/rest_framework_datatables/django_filters/backends.py
+++ b/rest_framework_datatables/django_filters/backends.py
@@ -62,6 +62,9 @@ class DatatablesFilterBackend(filters.DatatablesBaseFilterBackend,
         form_fields = {}
         field_queries = {}
         for f in query['fields']:
+            if 'data' not in f:
+                continue
+
             form_fields[f['data']] = f['search_value']
             field_queries[f['data']] = f
         query['form_fields'] = form_fields

--- a/tests/test_django_filter_backend.py
+++ b/tests/test_django_filter_backend.py
@@ -137,7 +137,8 @@ class TestInvalid(TestWithViewSet):
             '/api/albums/?format=datatables&length=10'
             '&columns[0][data]=artist'
             '&columns[0][searchable]=true'
-            '&columns[0][search][value]=Genesis')
+            '&columns[0][search][value]=Genesis'
+            '&columns[1][data]=')
 
     def test(self):
         self.assertEqual(self.response.status_code, 400)


### PR DESCRIPTION
This may occur if `django_filters.backends.DatatablesFilterBackend` is used and the JS side supplies an [empty `data` field](https://github.com/izimobil/django-rest-framework-datatables/blob/97168fec3e89c3abc3ab160a6b39d712b9aab359/rest_framework_datatables/filters.py#L58).