### PR TITLE
 fix unexpected results while using the searchCols

### DIFF
--- a/rest_framework_datatables/filters.py
+++ b/rest_framework_datatables/filters.py
@@ -200,7 +200,9 @@ class DatatablesFilterBackend(DatatablesBaseFilterBackend):
         initial_q = Q()
         for f in datatables_query['fields']:
             if f.get('search_value'):
-                initial_q &= f_search_q(f, f.get('search_value'), f.get('search_regex', False))
+                initial_q &= f_search_q(f,
+                                        f.get('search_value'),
+                                        f.get('search_regex', False))
         for f in datatables_query['fields']:
             if not f['searchable']:
                 continue

--- a/rest_framework_datatables/filters.py
+++ b/rest_framework_datatables/filters.py
@@ -197,15 +197,16 @@ class DatatablesFilterBackend(DatatablesBaseFilterBackend):
 
     def get_q(self, datatables_query):
         q = Q()
+        initial_q = Q()
+        for f in datatables_query['fields']:
+            if f.get('search_value'):
+                initial_q &= f_search_q(f, f.get('search_value'), f.get('search_regex', False))
         for f in datatables_query['fields']:
             if not f['searchable']:
                 continue
-            q |= f_search_q(f,
-                            datatables_query['search_value'],
-                            datatables_query['search_regex'])
-            q &= f_search_q(f,
-                            f.get('search_value'),
-                            f.get('search_regex', False))
+            query = f_search_q(f, datatables_query['search_value'], datatables_query['search_regex'])
+            query &= initial_q
+            q |= query
         return q
 
     def get_ordering(self, request, view, fields):

--- a/rest_framework_datatables/filters.py
+++ b/rest_framework_datatables/filters.py
@@ -199,16 +199,14 @@ class DatatablesFilterBackend(DatatablesBaseFilterBackend):
         q = Q()
         initial_q = Q()
         for f in datatables_query['fields']:
-            if f.get('search_value'):
-                initial_q &= f_search_q(f,
-                                        f.get('search_value'),
-                                        f.get('search_regex', False))
-        for f in datatables_query['fields']:
             if not f['searchable']:
                 continue
             q |= f_search_q(f,
                             datatables_query['search_value'],
                             datatables_query['search_regex'])
+            initial_q &= f_search_q(f,
+                                    f.get('search_value'),
+                                    f.get('search_regex', False))
         q &= initial_q
         return q
 

--- a/rest_framework_datatables/filters.py
+++ b/rest_framework_datatables/filters.py
@@ -1,9 +1,8 @@
+import operator
 import re
 from functools import reduce
-import operator
 
 from django.db.models import Q
-
 from rest_framework.filters import BaseFilterBackend
 
 from .utils import get_param
@@ -151,6 +150,7 @@ class DatatablesFilterBackend(DatatablesBaseFilterBackend):
     """
     Filter that works with datatables params.
     """
+
     def filter_queryset(self, request, queryset, view):
         """filter the queryset
 
@@ -204,9 +204,10 @@ class DatatablesFilterBackend(DatatablesBaseFilterBackend):
         for f in datatables_query['fields']:
             if not f['searchable']:
                 continue
-            query = f_search_q(f, datatables_query['search_value'], datatables_query['search_regex'])
-            query &= initial_q
-            q |= query
+            q |= f_search_q(f,
+                            datatables_query['search_value'],
+                            datatables_query['search_regex'])
+        q &= initial_q
         return q
 
     def get_ordering(self, request, view, fields):

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -86,6 +86,14 @@ class TestFilterTestCase(TestCase):
         result = response.json()
         self.assertEquals((result['recordsFiltered'], result['recordsTotal']), expected)
 
+    @override_settings(ROOT_URLCONF=__name__)
+    def test_search_over_filters_backend2(self):
+        response = self.client.get('/api/filter/albums/?format=datatables&length=10&columns[0][data]=rank&columns[0][searchable]=false&columns[1][data]=artist.name&columns[1][searchable]=true&columns[2][data]=name&columns[2][searchable]=true&columns[3][data]=year&columns[3][searchable]=true&columns[3][search][value]=1967&columns[4][data]=genres.name&columns[4][searchable]=true&search[value]=Velvet')
+        expected = (1, 15)
+
+        result = response.json()
+        self.assertEquals((result['recordsFiltered'], result['recordsTotal']), expected)
+
 urlpatterns = [
     url('^api/additionalorderby', TestFilterTestCase.TestAPIView.as_view()),
     url('^api/multiplefilterbackends', TestFilterTestCase.TestAPIView2.as_view()),

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -38,6 +38,12 @@ class TestFilterTestCase(TestCase):
         def get_queryset(self):
             return Album.objects.all()
 
+    class TestAPIView3(ListAPIView):
+        serializer_class = AlbumSerializer
+        filter_backends = [DatatablesFilterBackend]
+
+        def get_queryset(self):
+            return Album.objects.all()
 
     fixtures = ['test_data']
 
@@ -66,8 +72,22 @@ class TestFilterTestCase(TestCase):
         result = response.json()
         self.assertEquals((result['recordsFiltered'], result['recordsTotal']), expected)
 
+    @override_settings(ROOT_URLCONF=__name__)
+    def test_search_over_filters_backend1(self):
+        """Search over all columns
+
+        Searches should be made over all columns data
+        (It can be manual tested on 'Full example with foreign key and many to many relation' table)
+
+        """
+        response = self.client.get('/api/filter/albums/?format=datatables&length=10&columns[0][data]=rank&columns[0][searchable]=false&columns[1][data]=artist.name&columns[1][searchable]=true&columns[2][data]=name&columns[2][searchable]=true&columns[3][data]=year&columns[3][searchable]=true&columns[3][search][value]=1966&columns[4][data]=genres.name&columns[4][searchable]=true&search[value]=Blues')
+        expected = (1, 15)
+
+        result = response.json()
+        self.assertEquals((result['recordsFiltered'], result['recordsTotal']), expected)
 
 urlpatterns = [
     url('^api/additionalorderby', TestFilterTestCase.TestAPIView.as_view()),
     url('^api/multiplefilterbackends', TestFilterTestCase.TestAPIView2.as_view()),
+    url('^api/filter/albums', TestFilterTestCase.TestAPIView3.as_view()),
 ]


### PR DESCRIPTION
fix(filters.DatatablesFilterBackend.get_q): fix unexpected behaviors of get_q function while using the searchCols parameter of the datatables (it should apply the initial filters to all queries with AND)

more info: https://datatables.net/forums/discussion/comment/194448#Comment_194448