### PR TITLE
Update django-filters.rst

### DIFF
--- a/docs/django-filters.rst
+++ b/docs/django-filters.rst
@@ -31,7 +31,7 @@ import from the ``django_filters`` subpackage.
         pass
 
 
-    class AlbumGlobalFilter(GlobalFilter):
+    class AlbumGlobalFilter(DatatablesFilterSet):
         """Filter name, artist and genre by name with icontains"""
 
         name = GlobalCharFilter(lookup_expr='icontains')


### PR DESCRIPTION
What was done?

- Fix documentation by changing GlobalFilter to DatatablesFilterSet.

Following the example in docs, it return that `AlbumGlobalFilter has no attribute _meta`.