### PR TITLE
factor out order_queryset method

### DIFF
--- a/rest_framework_datatables/django_filters/backends.py
+++ b/rest_framework_datatables/django_filters/backends.py
@@ -39,12 +39,7 @@ class DatatablesFilterBackend(filters.DatatablesBaseFilterBackend,
 
         self.set_count_after(view, queryset.count())
 
-        # TODO Can we use OrderingFilter, maybe in DatatablesFilterSet, by
-        # default? See
-        # https://django-filter.readthedocs.io/en/master/ref/filters.html#ordering-filter
-        ordering = self.get_ordering(request, view, filterset)
-        if ordering:
-            queryset = queryset.order_by(*ordering)
+        queryset = self.order_queryset(queryset, request, view, filterset)
 
         return queryset
 
@@ -79,6 +74,15 @@ class DatatablesFilterBackend(filters.DatatablesBaseFilterBackend,
                     and hasattr(f, 'global_q')):
                 global_q |= f.global_q()
         return global_q
+
+    def order_queryset(self, queryset, request, view, filterset):
+        # TODO Can we use OrderingFilter, maybe in DatatablesFilterSet, by
+        # default? See
+        # https://django-filter.readthedocs.io/en/master/ref/filters.html#ordering-filter
+        ordering = self.get_ordering(request, view, filterset)
+        if ordering:
+            queryset = queryset.order_by(*ordering)
+        return queryset
 
     def get_ordering(self, request, view, filterset):
         ret = []

--- a/rest_framework_datatables/filters.py
+++ b/rest_framework_datatables/filters.py
@@ -189,9 +189,8 @@ class DatatablesFilterBackend(DatatablesBaseFilterBackend):
             filtered_count = filtered_count_before
         self.set_count_after(view, filtered_count)
 
-        ordering = self.get_ordering(request, view, datatables_query['fields'])
-        if ordering:
-            queryset = queryset.order_by(*ordering)
+        queryset = self.order_queryset(queryset, request, view,
+                                       datatables_query['fields'])
 
         return queryset
 
@@ -209,6 +208,12 @@ class DatatablesFilterBackend(DatatablesBaseFilterBackend):
                                     f.get('search_regex', False))
         q &= initial_q
         return q
+
+    def order_queryset(self, queryset, request, view, fields):
+        ordering = self.get_ordering(request, view, fields)
+        if ordering:
+            queryset = queryset.order_by(*ordering)
+        return queryset
 
     def get_ordering(self, request, view, fields):
         """called by parse_query_params to get the ordering


### PR DESCRIPTION
to make it easier to override ordering completely.

This is necessary to be able to use asc and desc with nulls_first or
nulls_last, see
https://docs.djangoproject.com/en/2.2/ref/models/expressions/#django.db.models.Expression.asc

I need this in another project, but I won't have time to port the
solution to django-rest-framework-datatables in the near future.

If you want to override order_queryset and use asc() and desc() you'll
probably need to inline most of get_ordering and add those asc/desc
calls to the queryset appropriately.