### PR TITLE
Dependency version updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - "3.8"
   - "3.9"
+  - "3.10"
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
 
 python:
-  - "3.8"
   - "3.9"
-  - "3.10"
 
 sudo: false
 

--- a/README.rst
+++ b/README.rst
@@ -191,7 +191,7 @@ To build the documentation:
 .. code:: bash
 
     $ cd docs
-    $ make clean && make build
+    $ make clean && make html
 
 
 .. _tox: http://tox.readthedocs.org/en/latest/

--- a/README.rst
+++ b/README.rst
@@ -20,15 +20,11 @@ You can play with a demo of the example app on `Python Anywhere <https://izimobi
 Requirements
 ------------
 
-- Python (3.7, 3.8, 3.9)
-- Django (2.0, 2.1, 2.2, 3.0, 3.1, 3.2, 4.0)
-- Django REST Framework (3.7, 3.8, 3.9, 3.10, 3.11, 3.12)
+- Python (3.7, 3.8, 3.9, 3.10)
+- Django (3.2, 4.0, 4.1)
+- Django REST Framework (3.14)
 
-Please note:
-
-- Django 3.X branch is only supported with Django REST Framework 3.11 or superior and DRF-datatables version 0.5.1 or superior.
-- Django 4.X branch is only supported with Django REST Framework 3.12 or superior and DRF-datatables version 0.7.0 or superior.
-
+We highly recommend and only officially support the latest patch release of each Python, Django and Django Rest Framework series.
 
 Quickstart
 ----------

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -13,6 +13,8 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 import os
 import sys
 
+import django
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.dirname(BASE_DIR))
@@ -129,7 +131,8 @@ TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
-USE_L10N = True
+if django.VERSION < (4, 0):
+    USE_L10N = True
 
 USE_TZ = True
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 coverage==6.5.0
 Django>=3.2
 djangorestframework>=3.14
-pycodestyle>=2.3
+pycodestyle>=2.9.1
 django-filter>=22.1
 pytz

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 coverage==4.5.1
-Django>=2.0
-djangorestframework>=3.7
+Django>=2.2
+djangorestframework>=3.12
 pycodestyle>=2.3
-django-filter>=2.4.0
+django-filter>=22.1
 pytz

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
-coverage==4.5.1
-Django>=2.2
-djangorestframework>=3.12
+coverage==6.5.0
+Django>=4.1
+djangorestframework>=3.14
 pycodestyle>=2.3
 django-filter>=22.1
 pytz

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 coverage==6.5.0
-Django>=4.1
+Django>=3.2
 djangorestframework>=3.14
 pycodestyle>=2.3
 django-filter>=22.1

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,2 +1,2 @@
-Sphinx==1.7.2
-sphinx-rtd-theme==0.3.0
+Sphinx==5.3.0
+sphinx-rtd-theme==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-djangorestframework>=3.12
+djangorestframework>=3.14
 pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-djangorestframework>=3.7
+djangorestframework>=3.12
 pytz

--- a/setup.py
+++ b/setup.py
@@ -87,16 +87,13 @@ setup(
         'rest_framework_datatables.django_filters'
     ],
     install_requires=[
-        'djangorestframework>=3.12.0',
+        'djangorestframework>=3.14.0',
         'pytz',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 2.2',
-        'Framework :: Django :: 3.0',
-        'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -87,20 +87,19 @@ setup(
         'rest_framework_datatables.django_filters'
     ],
     install_requires=[
-        'djangorestframework>=3.7.0',
+        'djangorestframework>=3.12.0',
         'pytz',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 2.0',
-        'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
+        'Framework :: Django :: 4.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
@@ -109,6 +108,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -46,15 +46,15 @@ class TestApiTestCase(TestCase):
         response = self.client.get('/api/albums/')
         expected = 15
         result = response.json()
-        self.assertEquals(result['count'], expected)
+        self.assertEqual(result['count'], expected)
 
     def test_datatables_query(self):
         response = self.client.get('/api/albums/?format=datatables')
         expected = 15
         result = response.json()
-        self.assertEquals('count' in result, False)
-        self.assertEquals('recordsTotal' in result, True)
-        self.assertEquals(result['recordsTotal'], expected)
+        self.assertEqual('count' in result, False)
+        self.assertEqual('recordsTotal' in result, True)
+        self.assertEqual(result['recordsTotal'], expected)
 
     @override_settings(ROOT_URLCONF=__name__)
     def test_post_request(self):
@@ -71,48 +71,48 @@ class TestApiTestCase(TestCase):
         )
         expected = (15, 15, 'The Velvet Underground')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
-        self.assertEquals((result['data'][0]['name']), 'The Velvet Underground & Nico')
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['data'][0]['name']), 'The Velvet Underground & Nico')
 
     def test_datatables_suffix(self):
         response = self.client.get('/api/albums.datatables/')
         expected = 15
         result = response.json()
-        self.assertEquals('count' in result, False)
-        self.assertEquals('recordsTotal' in result, True)
-        self.assertEquals(result['recordsTotal'], expected)
+        self.assertEqual('count' in result, False)
+        self.assertEqual('recordsTotal' in result, True)
+        self.assertEqual(result['recordsTotal'], expected)
 
     def test_pagenumber_pagination(self):
         response = self.client.get('/api/albums/?format=datatables&length=10&start=10&columns[0][data]=name&columns[1][data]=artist_name&draw=1')
         expected = (15, 15, 5, 'Elvis Presley')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], len(result['data']), result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], len(result['data']), result['data'][0]['artist_name']), expected)
 
     def test_pagenumber_pagination_show_all(self):
         response = self.client.get('/api/albums/?format=datatables&length=-1&columns[0][data]=name&columns[1][data]=artist_name&draw=1')
         expected = (15, 15, 15, 'The Beatles')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], len(result['data']), result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], len(result['data']), result['data'][0]['artist_name']), expected)
 
     def test_pagenumber_pagination_invalid_page1(self):
         response = self.client.get('/api/albums/?format=datatables&length=10&start=20&columns[0][data]=name&columns[1][data]=artist_name&draw=1')
-        self.assertEquals(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
     def test_pagenumber_pagination_invalid_page2(self):
         response = self.client.get('/api/albums/?format=datatables&length=10&start=abc&columns[0][data]=name&columns[1][data]=artist_name&draw=1')
-        self.assertEquals(response.status_code, 404)
+        self.assertEqual(response.status_code, 404)
 
     def test_pagenumber_pagination_invalid_page_size1(self):
         response = self.client.get('/api/albums/?format=datatables&length=abc&start=10&columns[0][data]=name&columns[1][data]=artist_name&draw=1')
         expected = (15, 15, 5, 'Elvis Presley')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], len(result['data']), result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], len(result['data']), result['data'][0]['artist_name']), expected)
 
     def test_pagenumber_pagination_invalid_page_size2(self):
         response = self.client.get('/api/albums/?format=datatables&length=-999&start=10&columns[0][data]=name&columns[1][data]=artist_name&draw=1')
         expected = (15, 15, 5, 'Elvis Presley')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], len(result['data']), result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], len(result['data']), result['data'][0]['artist_name']), expected)
 
     @override_settings(REST_FRAMEWORK={
         'DEFAULT_PAGINATION_CLASS': __name__ + '.DatatablesPageNumberPaginationCustomMax',
@@ -122,7 +122,7 @@ class TestApiTestCase(TestCase):
         response = self.client.get('/api/albums/?format=datatables&length=20&start=10&columns[0][data]=name&columns[1][data]=artist_name&draw=1')
         expected = (15, 15, 15, 'The Beatles')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], len(result['data']), result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], len(result['data']), result['data'][0]['artist_name']), expected)
 
     @override_settings(REST_FRAMEWORK={
         'DEFAULT_PAGINATION_CLASS': 'rest_framework_datatables.pagination.DatatablesLimitOffsetPagination',
@@ -133,7 +133,7 @@ class TestApiTestCase(TestCase):
         response = client.get('/api/albums/?format=datatables&length=10&start=10&columns[0][data]=name&columns[1][data]=artist_name&draw=1')
         expected = (15, 15, 'Elvis Presley')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
 
     @override_settings(REST_FRAMEWORK={
         'DEFAULT_PAGINATION_CLASS': 'rest_framework_datatables.pagination.DatatablesLimitOffsetPagination',
@@ -144,7 +144,7 @@ class TestApiTestCase(TestCase):
         response = client.get('/api/albums/?format=datatables&start=10&columns[0][data]=name&columns[1][data]=artist_name&length=-1&draw=1')
         expected = (15, 15, 'The Beatles')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
 
     @override_settings(REST_FRAMEWORK={
         'DEFAULT_PAGINATION_CLASS': 'rest_framework_datatables.pagination.DatatablesLimitOffsetPagination',
@@ -156,7 +156,7 @@ class TestApiTestCase(TestCase):
             '/api/albums/?format=datatables&length=abc&start=10&columns[0][data]=name&columns[1][data]=artist_name&draw=1')
         expected = (15, 15, 'Elvis Presley')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
 
     @override_settings(REST_FRAMEWORK={
         'DEFAULT_PAGINATION_CLASS': 'rest_framework_datatables.pagination.DatatablesLimitOffsetPagination',
@@ -168,7 +168,7 @@ class TestApiTestCase(TestCase):
             '/api/albums/?format=datatables&length=-999&start=10&columns[0][data]=name&columns[1][data]=artist_name&draw=1')
         expected = (15, 15, 'Elvis Presley')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
 
     @override_settings(REST_FRAMEWORK={
         'DEFAULT_PAGINATION_CLASS': 'rest_framework_datatables.pagination.DatatablesLimitOffsetPagination',
@@ -180,7 +180,7 @@ class TestApiTestCase(TestCase):
             '/api/albums/?format=datatables&length=10&start=abc&columns[0][data]=name&columns[1][data]=artist_name&draw=1')
         expected = (15, 15, 'The Beatles')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
 
     @override_settings(REST_FRAMEWORK={
         'DEFAULT_PAGINATION_CLASS': 'rest_framework_datatables.pagination.DatatablesLimitOffsetPagination',
@@ -192,7 +192,7 @@ class TestApiTestCase(TestCase):
             '/api/albums/?format=datatables&length=10&start=-999&columns[0][data]=name&columns[1][data]=artist_name&draw=1')
         expected = (15, 15, 'The Beatles')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
 
     @override_settings(REST_FRAMEWORK={
         'DEFAULT_PAGINATION_CLASS': __name__ + '.DatatablesLimitOffsetPaginationCustomMax',
@@ -204,7 +204,7 @@ class TestApiTestCase(TestCase):
             '/api/albums/?format=datatables&length=20&start=10&columns[0][data]=name&columns[1][data]=artist_name&draw=1')
         expected = (15, 15, 'Elvis Presley')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
 
     @override_settings(REST_FRAMEWORK={
         'DEFAULT_PAGINATION_CLASS': 'rest_framework_datatables.pagination.DatatablesLimitOffsetPagination',
@@ -215,13 +215,13 @@ class TestApiTestCase(TestCase):
         response = client.get('/api/albums/?limit=10&offset=10')
         expected = (15, 'Elvis Presley')
         result = response.json()
-        self.assertEquals((result['count'], result['results'][0]['artist_name']), expected)
+        self.assertEqual((result['count'], result['results'][0]['artist_name']), expected)
 
     def test_column_column_data_null(self):
         response = self.client.get('/api/albums/?format=datatables&length=10&start=10&columns[0][data]=&columns[1][data]=name')
         expected = (15, 15, 'The Sun Sessions')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['name']), expected)
 
     def test_dt_row_attrs_present(self):
         response = self.client.get('/api/albums/?format=datatables&length=10&start=0&columns[0][data]=&columns[1][data]=name')
@@ -242,13 +242,13 @@ class TestApiTestCase(TestCase):
             '/api/albums/?format=datatables&length=10&columns[0][data]=artist.name&columns[0][name]=artist.name&keep=year')
         expected = (15, 15, 1967)
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['year']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['year']), expected)
 
     def test_param_keep_field_search(self):
         response = self.client.get('/api/albums/?format=datatables&length=10&columns[0][data]=artist.name&columns[0][name]=artist.name,year&columns[0][searchable]=true&keep=year&search[value]=1968')
         expected = (1, 15, 'The Beatles', 1968)
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist']['name'], result['data'][0]['year']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist']['name'], result['data'][0]['year']), expected)
 
     def test_dt_force_serialize_generic(self):
         response = self.client.get('/api/artists/?format=datatables&length=10&start=0&columns[0][data]=&columns[1][data]=name')
@@ -259,7 +259,7 @@ class TestApiTestCase(TestCase):
         response = self.client.get('/api/albums/?format=datatables&columns[0][data]=name&columns[0][searchable]=true&columns[1][data]=artist__name&columns[1][searchable]=true&search[value]=are+you+exp')
         expected = (1, 15, 'Are You Experienced')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['name']), expected)
 
     def test_filtering_multiple_names(self):
         # Two asserts here to test searching on separate namespaces.
@@ -272,81 +272,81 @@ class TestApiTestCase(TestCase):
         expected_2 = (1, 15, 'The Beatles ("The White Album")')
         result_1 = response_1.json()
         result_2 = response_2.json()
-        self.assertEquals((result_1['recordsFiltered'], result_1['recordsTotal'], result_1['data'][0]['name']), expected_1)
-        self.assertEquals((result_2['recordsFiltered'], result_2['recordsTotal'], result_2['data'][0]['name']), expected_2)
+        self.assertEqual((result_1['recordsFiltered'], result_1['recordsTotal'], result_1['data'][0]['name']), expected_1)
+        self.assertEqual((result_2['recordsFiltered'], result_2['recordsTotal'], result_2['data'][0]['name']), expected_2)
 
     def test_filtering_regex(self):
         response = self.client.get('/api/albums/?format=datatables&length=10&columns[0][data]=name&columns[0][searchable]=true&search[regex]=true&search[value]=^Highway [0-9]{2} Revisited$')
         expected = (1, 15, 'Highway 61 Revisited')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['name']), expected)
 
     def test_filtering_bad_regex(self):
         response = self.client.get('/api/albums/?format=datatables&length=10&columns[0][data]=name&columns[0][searchable]=true&search[regex]=true&search[value]=^Highway [0')
         expected = (15, 15, 'Sgt. Pepper\'s Lonely Hearts Club Band')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['name']), expected)
 
     def test_filtering_foreignkey_without_nested_serializer(self):
         response = self.client.get('/api/albums/?format=datatables&length=10&columns[0][data]=artist_name&columns[0][name]=artist__name&columns[0][searchable]=true&search[value]=Jimi')
         expected = (1, 15, 'The Jimi Hendrix Experience')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
 
     def test_filtering_foreignkey_with_nested_serializer(self):
         response = self.client.get(
             '/api/albums/?format=datatables&length=10&columns[0][data]=artist.name&columns[0][name]=artist.name&columns[0][searchable]=true&search[value]=Jimi')
         expected = (1, 15, 'The Jimi Hendrix Experience')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist']['name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist']['name']), expected)
 
     def test_filtering_column(self):
         response = self.client.get('/api/albums/?format=datatables&length=10&columns[0][data]=artist_name&columns[0][name]=artist__name&columns[0][searchable]=true&columns[0][search][value]=Beatles')
         expected = (5, 15, 'The Beatles')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
 
     def test_filtering_column_suffix(self):
         response = self.client.get('/api/albums.datatables?length=10&columns[0][data]=artist_name&columns[0][name]=artist__name&columns[0][searchable]=true&columns[0][search][value]=Beatles')
         expected = (5, 15, 'The Beatles')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
 
     def test_filtering_column_regex(self):
         response = self.client.get('/api/albums/?format=datatables&length=10&columns[0][data]=artist_name&columns[0][name]=artist__name&columns[0][searchable]=true&columns[0][search][regex]=true&columns[0][search][value]=^bob')
         expected = (2, 15, 'Bob Dylan')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
 
     def test_filtering_multicolumn1(self):
         response = self.client.get('/api/albums/?format=datatables&length=10&columns[0][data]=artist_name&columns[0][name]=artist__name&columns[0][searchable]=true&columns[0][search][value]=Beatles&columns[1][data]=year&columns[1][searchable]=true&columns[1][search][value]=1968')
         expected = (1, 15, 'The Beatles')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
 
     def test_filtering_multicolumn2(self):
         response = self.client.get('/api/albums/?format=datatables&length=10&columns[0][data]=artist_name&columns[0][name]=artist__name&columns[0][searchable]=true&columns[0][search][value]=Beatles&columns[1][data]=year&columns[1][searchable]=true&columns[1][search][value]=2018')
         expected = (0, 15)
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal']), expected)
 
     def test_ordering_simple(self):
         response = self.client.get('/api/albums/?format=datatables&length=10&columns[0][data]=artist_name&columns[0][name]=artist__name&columns[0][orderable]=true&order[0][column]=0&order[0][dir]=desc')
         expected = (15, 15, 'The Velvet Underground')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
 
     def test_ordering_but_not_orderable(self):
         response = self.client.get('/api/albums/?format=datatables&length=10&columns[0][data]=artist_name&columns[0][name]=artist__name&columns[0][orderable]=false&order[0][column]=0&order[0][dir]=desc')
         expected = (15, 15, 'The Beatles')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
 
     def test_ordering_bad_column_index(self):
         response = self.client.get('/api/albums/?format=datatables&length=10&columns[0][data]=artist_name&columns[0][name]=artist__name&columns[0][orderable]=true&order[0][column]=8&order[0][dir]=desc')
         expected = (15, 15, 'The Beatles')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['artist_name']), expected)
 
     @override_settings(REST_FRAMEWORK={
         'DEFAULT_PAGINATION_CLASS': __name__ + '.DatatablesOnlyPageNumberPaginationCustomMax',
@@ -356,14 +356,14 @@ class TestApiTestCase(TestCase):
         response = self.client.get('/api/albums/')
         expected = (list, 15)
         result = response.json()
-        self.assertEquals((type(result), len(result)), expected)
+        self.assertEqual((type(result), len(result)), expected)
 
     def test_datatables_only_pagination_with_datatables(self):
         AlbumViewSet.pagination_class = DatatablesOnlyPageNumberPaginationCustomMax
         response = self.client.get('/api/albums/?format=datatables&length=20&start=10&columns[0][data]=name&columns[1][data]=artist_name&draw=1')
         expected = (15, 15, 15, 'The Beatles')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], len(result['data']), result['data'][0]['artist_name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], len(result['data']), result['data'][0]['artist_name']), expected)
 
 
 urlpatterns = [

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -2,7 +2,7 @@ from albums.models import Album
 from albums.serializers import AlbumSerializer
 
 from django.urls import path
-from django.test.utils import override_settings, modify_settings
+from django.test.utils import override_settings
 from django.test import TestCase
 
 from rest_framework.generics import ListAPIView
@@ -56,21 +56,21 @@ class TestFilterTestCase(TestCase):
         # Would be "Sgt. Pepper's Lonely Hearts Club Band" without the additional order by
         expected = (15, 15, 'Rubber Soul')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['name']), expected)
 
     @override_settings(ROOT_URLCONF=__name__)
     def test_multiple_filters_backend1(self):
         response = self.client.get('/api/multiplefilterbackends/?format=datatables&columns[0][data]=name&columns[0][searchable]=true&columns[1][data]=artist__name&columns[1][searchable]=true&search[value]=are+you+exp')
         expected = (1, 15, 'Are You Experienced')
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['name']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal'], result['data'][0]['name']), expected)
 
     @override_settings(ROOT_URLCONF=__name__)
     def test_multiple_filters_backend2(self):
         response = self.client.get('/api/multiplefilterbackends/?format=datatables&columns[0][data]=name&columns[0][searchable]=true&columns[1][data]=artist__name&columns[1][searchable]=true&search[value]=white')
         expected = (0, 15)
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal']), expected)
 
     @override_settings(ROOT_URLCONF=__name__)
     def test_search_over_filters_backend1(self):
@@ -84,7 +84,7 @@ class TestFilterTestCase(TestCase):
         expected = (1, 15)
 
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal']), expected)
 
     @override_settings(ROOT_URLCONF=__name__)
     def test_search_over_filters_backend2(self):
@@ -92,7 +92,7 @@ class TestFilterTestCase(TestCase):
         expected = (1, 15)
 
         result = response.json()
-        self.assertEquals((result['recordsFiltered'], result['recordsTotal']), expected)
+        self.assertEqual((result['recordsFiltered'], result['recordsTotal']), expected)
 
 urlpatterns = [
     path('api/additionalorderby/', TestFilterTestCase.TestAPIView.as_view()),

--- a/tests/test_renderers.py
+++ b/tests/test_renderers.py
@@ -15,7 +15,7 @@ class DatatablesRendererTestCase(TestCase):
     def test_render_no_data(self):
         renderer = DatatablesRenderer()
         content = renderer.render(None)
-        self.assertEquals(content, bytes())
+        self.assertEqual(content, bytes())
 
     def test_render_no_pagination1(self):
         obj = [{'foo': 'bar'}]
@@ -31,7 +31,7 @@ class DatatablesRendererTestCase(TestCase):
             'data': [{'foo': 'bar'}],
             'draw': 1
         }
-        self.assertEquals(json.loads(content.decode('utf-8')), expected)
+        self.assertEqual(json.loads(content.decode('utf-8')), expected)
 
     def test_render_no_pagination1_1(self):
         obj = [{'foo': 'bar'}]
@@ -47,7 +47,7 @@ class DatatablesRendererTestCase(TestCase):
             'data': [{'foo': 'bar'}],
             'draw': 1
         }
-        self.assertEquals(json.loads(content.decode('utf-8')), expected)
+        self.assertEqual(json.loads(content.decode('utf-8')), expected)
 
     def test_render_no_pagination2(self):
         obj = {'results': [{'foo': 'bar'}, {'spam': 'eggs'}]}
@@ -63,7 +63,7 @@ class DatatablesRendererTestCase(TestCase):
             'data': [{'foo': 'bar'}, {'spam': 'eggs'}],
             'draw': 1
         }
-        self.assertEquals(json.loads(content.decode('utf-8')), expected)
+        self.assertEqual(json.loads(content.decode('utf-8')), expected)
 
     def test_render_no_pagination3(self):
         obj = {'results': [{'foo': 'bar'}, {'spam': 'eggs'}]}
@@ -81,7 +81,7 @@ class DatatablesRendererTestCase(TestCase):
             'data': [{'foo': 'bar'}, {'spam': 'eggs'}],
             'draw': 1
         }
-        self.assertEquals(json.loads(content.decode('utf-8')), expected)
+        self.assertEqual(json.loads(content.decode('utf-8')), expected)
 
     def test_render(self):
         obj = {'recordsTotal': 4, 'recordsFiltered': 2, 'data': [{'foo': 'bar'}, {'spam': 'eggs'}]}
@@ -97,7 +97,7 @@ class DatatablesRendererTestCase(TestCase):
             'data': [{'foo': 'bar'}, {'spam': 'eggs'}],
             'draw': 2
         }
-        self.assertEquals(json.loads(content.decode('utf-8')), expected)
+        self.assertEqual(json.loads(content.decode('utf-8')), expected)
 
     def test_render_extra_json(self):
         class TestAPIView(APIView):
@@ -120,7 +120,7 @@ class DatatablesRendererTestCase(TestCase):
             'key': 'value',
             'draw': 2
         }
-        self.assertEquals(json.loads(content.decode('utf-8')), expected)
+        self.assertEqual(json.loads(content.decode('utf-8')), expected)
 
     def test_render_extra_json_attr_missing(self):
         class TestAPIView(APIView):

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
 envlist =
-       {py37,py38,py39,py310}-django32-drf3.14-df22.1,
-       {py38,py39,py310}-{django40,django41,djangomain}-drf3.14-df22.1,
-       py310-lint,
-       {py38,py39}-django3.{1,2}-drf3.14-df22.1
-       {py39}-django4.{0,1}-drf3.14-df22.1
+       {py37,py38,py39,py310,py311}-django32-drf3.14-df22.1,
+       {py38,py39,py310,py311}-{django40,django41,djangomain}-drf3.14-df22.1,
+       py311-lint,
+       {py38,py39,py310,py311}-django3.{1,2}-drf3.14-df22.1
 
 [testenv]
 commands = coverage run --source=rest_framework_datatables example/manage.py test --noinput
@@ -19,7 +18,7 @@ deps =
        drf3.14: djangorestframework>=3.14,<3.15
        df22.1: django-filter>=22.1
 
-[testenv:py310-lint]
+[testenv:py311-lint]
 commands = pycodestyle rest_framework_datatables
 deps =
        pycodestyle>=2.9.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,12 @@
 [tox]
 envlist =
-       py39-lint,
-       {py38}-django2.{0,1,2}-drf3.{7,8,9}-df2.2
-       {py38,py39}-django3.{0,1,2}-drf3.{11,12}-df2.2
-       {py39}-django4.{0}-drf3.{12}-df2.2
+       {py37,py38,py39}-django30-drf3.14-df22.1,
+       {py37,py38,py39}-django31-drf3.14-df22.1,
+       {py37,py38,py39,py310}-django32-drf3.14-df22.1,
+       {py38,py39,py310}-{django40,django41,djangomain}-drf3.14-df22.1,
+       py310-lint,
+       {py38,py39}-django3.{0,1,2}-drf3.14-df2.2
+       {py39}-django4.{0,1}-drf3.14-df2.2
 
 [testenv]
 commands = coverage run --source=rest_framework_datatables example/manage.py test --noinput
@@ -11,19 +14,14 @@ setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
        coverage
-       django2.0: Django>=2.0,<2.1
-       django2.1: Django>=2.1,<2.2
-       django2.2: Django>=2.2,<3.0
-       django3.0: Django>=3.0,<3.1
-       django3.1: Django>=3.1,<3.2
-       django3.2: Django>=3.2,<4.0
-       django4.0: Django>=4.0,<4.1
-       drf3.7: djangorestframework>=3.7,<3.8
-       drf3.8: djangorestframework>=3.8,<3.9
-       drf3.9: djangorestframework>=3.9,<3.10
-       drf3.11: djangorestframework>=3.11,<3.12
-       drf3.12: djangorestframework>=3.12,<3.13
-       df2.2: django-filter>=2.2.0
+       django30: Django>=3.0,<3.1
+       django31: Django>=3.1,<3.2
+       django32: Django>=3.2,<4.0
+       django40: Django>=4.0,<4.1
+       django41: Django>=4.1a1,<4.2
+       djangomain: https://github.com/django/django/archive/main.tar.gz
+       drf3.14: djangorestframework>=3.14,<3.15
+       df22.1: django-filter>=22.1
 
 [testenv:py39-lint]
 commands = pycodestyle rest_framework_datatables

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
 envlist =
-       {py37,py38,py39}-django30-drf3.14-df22.1,
-       {py37,py38,py39}-django31-drf3.14-df22.1,
        {py37,py38,py39,py310}-django32-drf3.14-df22.1,
        {py38,py39,py310}-{django40,django41,djangomain}-drf3.14-df22.1,
        py310-lint,
-       {py38,py39}-django3.{0,1,2}-drf3.14-df2.2
-       {py39}-django4.{0,1}-drf3.14-df2.2
+       {py38,py39}-django3.{1,2}-drf3.14-df22.1
+       {py39}-django4.{0,1}-drf3.14-df22.1
 
 [testenv]
 commands = coverage run --source=rest_framework_datatables example/manage.py test --noinput
@@ -14,16 +12,14 @@ setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
        coverage
-       django30: Django>=3.0,<3.1
-       django31: Django>=3.1,<3.2
        django32: Django>=3.2,<4.0
        django40: Django>=4.0,<4.1
-       django41: Django>=4.1a1,<4.2
+       django41: Django>=4.1,<4.2
        djangomain: https://github.com/django/django/archive/main.tar.gz
        drf3.14: djangorestframework>=3.14,<3.15
        df22.1: django-filter>=22.1
 
-[testenv:py39-lint]
+[testenv:py310-lint]
 commands = pycodestyle rest_framework_datatables
 deps =
-       pycodestyle>=2.3.0
+       pycodestyle>=2.9.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,18 @@
 [tox]
 envlist =
-       {py37,py38,py39,py310,py311}-django32-drf3.14-df22.1,
-       {py38,py39,py310,py311}-{django40,django41,djangomain}-drf3.14-df22.1,
-       py311-lint,
-       {py38,py39,py310,py311}-django3.{1,2}-drf3.14-df22.1
+       {py37,py38,py39,py310}-django32-drf3.14-df22.1,
+       {py38,py39,py310}-{django40,django41,djangomain}-drf3.14-df22.1,
+       py311-{django41,djangomain}-drf3.14-df22.1,
+       py311-lint
 
 [testenv]
-commands = coverage run --source=rest_framework_datatables example/manage.py test --noinput
+commands =
+       python -W error::DeprecationWarning -W error::PendingDeprecationWarning \
+       -m coverage run example/manage.py test --noinput
+
 setenv =
        PYTHONDONTWRITEBYTECODE=1
+       PYTHONPATH = {toxinidir}/example
 deps =
        coverage
        django32: Django>=3.2,<4.0


### PR DESCRIPTION
The existing dependencies referenced django versions which are now past [end of life](https://endoflife.date/django).

- Have updated dependencies to remove reference to EOL packages
- Have replaced deprecated `assertEquals()` calls with `assertEqual()`
