### PR TITLE
Remove pytz from package requires

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,3 @@ Django>=3.2
 djangorestframework>=3.14
 pycodestyle>=2.9.1
 django-filter>=22.1
-pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 djangorestframework>=3.14
-pytz

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,6 @@ setup(
     ],
     install_requires=[
         'djangorestframework>=3.14.0',
-        'pytz',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This package is being removed from Django and DRF in favour of the `zoneinfo` module from the standard library. As far as I can tell, django-rest-framework-datatables is not using `pytz` directly, so I suggest to remove it from its dependencies, and let it be installed when DRF or Django need it.