### PR TITLE
standardised params for get_queryset_count_before / after

### DIFF
--- a/rest_framework_datatables/django_filters/backends.py
+++ b/rest_framework_datatables/django_filters/backends.py
@@ -39,7 +39,9 @@ class DatatablesFilterBackend(filters.DatatablesBaseFilterBackend,
         if global_q:
             queryset = queryset.filter(global_q).distinct()
 
-        count = self.get_queryset_count_after(request, queryset, view)
+        count = self.get_queryset_count_after(
+            request, queryset, view
+        )
         self.set_count_after(view, count)
 
         # TODO Can we use OrderingFilter, maybe in DatatablesFilterSet, by

--- a/rest_framework_datatables/django_filters/backends.py
+++ b/rest_framework_datatables/django_filters/backends.py
@@ -22,13 +22,13 @@ class DatatablesFilterBackend(filters.DatatablesBaseFilterBackend,
         if not self.check_renderer_format(request):
             return queryset
 
-        count = self.get_queryset_count_before(view.get_queryset())
+        count = self.get_queryset_count_before(request, view.get_queryset(), view)
         self.set_count_before(view, count)
 
         # parsed datatables_query will be an attribute of the filterset
         filterset = self.get_filterset(request, queryset, view)
         if filterset is None:
-            count = self.get_queryset_count_after(queryset)
+            count = self.get_queryset_count_after(request, queryset, view)
             self.set_count_after(view, count)
             return queryset
 
@@ -39,7 +39,7 @@ class DatatablesFilterBackend(filters.DatatablesBaseFilterBackend,
         if global_q:
             queryset = queryset.filter(global_q).distinct()
 
-        count = self.get_queryset_count_after(queryset)
+        count = self.get_queryset_count_after(request, queryset, view)
         self.set_count_after(view, count)
 
         # TODO Can we use OrderingFilter, maybe in DatatablesFilterSet, by
@@ -98,7 +98,7 @@ class DatatablesFilterBackend(filters.DatatablesBaseFilterBackend,
         self.append_additional_ordering(ret, view)
         return ret
 
-    def get_queryset_count_before(self, queryset):
+    def get_queryset_count_before(self, request, queryset, view):
         """
         Provide an overrideable method to return a custom count.
         This can be useful for very large tables, as calls to model.count()
@@ -106,7 +106,7 @@ class DatatablesFilterBackend(filters.DatatablesBaseFilterBackend,
         """
         return queryset.count()
 
-    def get_queryset_count_after(self, queryset):
+    def get_queryset_count_after(self, request, queryset, view):
         """
         See
         :meth:`~rest_framework_datatables.django_filters.backends.DatatablesFilterBackend.get_queryset_count_before`.

--- a/tests/test_django_filter_backend.py
+++ b/tests/test_django_filter_backend.py
@@ -30,10 +30,10 @@ class CustomDatatablesFilterBackend(DatatablesFilterBackend):
     Override before and after counts to demonstrate performance fix.
     """
 
-    def get_queryset_count_before(self, queryset):
+    def get_queryset_count_before(self, request, queryset, view):
         return 999
 
-    def get_queryset_count_after(self, queryset):
+    def get_queryset_count_after(self, request, queryset, view):
         return 99
 
 


### PR DESCRIPTION
Extension to #149 which includes the params passed into the parent method.
This is useful if the override of count needs to depend on other params.

Note this will break the interface released in 0.7.2, which means that anyone who has overridded `get_queryset_count_before` or `get_queryset_count_after` will have to update their code.   We can change the param order or add kwargs to avoid this if required.